### PR TITLE
Revert "Add admin-warning feature for critical deprecations"

### DIFF
--- a/assets/javascripts/discourse/services/deprecation-collector.js
+++ b/assets/javascripts/discourse/services/deprecation-collector.js
@@ -1,14 +1,11 @@
 import { registerDeprecationHandler } from "@ember/debug";
 import { cancel } from "@ember/runloop";
 import Service, { inject as service } from "@ember/service";
-import { withPluginApi } from "discourse/lib/plugin-api";
 import identifySource from "discourse/lib/source-identifier";
-import { escapeExpression } from "discourse/lib/utilities";
 import discourseDebounce from "discourse-common/lib/debounce";
 import { registerDeprecationHandler as registerDiscourseDeprecationHandler } from "discourse-common/lib/deprecated";
 import getURL from "discourse-common/lib/get-url";
 import { bind } from "discourse-common/utils/decorators";
-import I18n from "discourse-i18n";
 
 // Deprecation handling APIs don't have any way to unregister handlers, so we set up permenant
 // handlers and link them up to the application lifecycle using module-local state.
@@ -21,20 +18,12 @@ registerDiscourseDeprecationHandler((message, opts) =>
   handler?.(message, opts)
 );
 
-const CRITICAL_DEPRECATIONS = [
-  /^discourse.modal-controllers$/,
-  /^(?!discourse\.)/,
-];
-
 export default class DeprecationCollector extends Service {
   @service router;
-  @service currentUser;
-  @service siteSettings;
 
   #configById = new Map();
   #counts = new Map();
   #reportDebounce;
-  #adminWarned = false;
 
   constructor() {
     super(...arguments);
@@ -74,12 +63,9 @@ export default class DeprecationCollector extends Service {
       return;
     }
 
-    const source = identifySource();
-    if (source?.type === "browser-extension") {
+    if (identifySource()?.type === "browser-extension") {
       return;
     }
-
-    this.maybeNotifyAdmin(options.id, source);
 
     let count = this.#counts.get(options.id) || 0;
     count += 1;
@@ -106,54 +92,5 @@ export default class DeprecationCollector extends Service {
     body.append("data", JSON.stringify(data));
 
     navigator.sendBeacon(getURL("/deprecation-collector/log"), body);
-  }
-
-  maybeNotifyAdmin(id, source) {
-    if (this.#adminWarned) {
-      return;
-    }
-
-    if (!this.currentUser?.admin) {
-      return;
-    }
-
-    if (!this.siteSettings?.deprecation_collector_warn_critical_deprecations) {
-      return;
-    }
-
-    if (CRITICAL_DEPRECATIONS.some((pattern) => pattern.test(id))) {
-      this.notifyAdmin(id, source);
-    }
-  }
-
-  notifyAdmin(id, source) {
-    this.#adminWarned = true;
-
-    let notice = I18n.t("deprecation_collector.critical_deprecations");
-
-    if (
-      this.siteSettings?.deprecation_collector_critical_deprecations_message
-    ) {
-      notice +=
-        " " +
-        this.siteSettings.deprecation_collector_critical_deprecations_message;
-    }
-
-    if (source?.type === "theme") {
-      notice +=
-        " " +
-        I18n.t("deprecation_collector.theme_source", {
-          name: escapeExpression(source.name),
-          path: source.path,
-        });
-    }
-
-    withPluginApi("0.1", (api) => {
-      api.addGlobalNotice(notice, "critical-deprecation", {
-        dismissable: true,
-        dismissDuration: moment.duration(1, "day"),
-        level: "warn",
-      });
-    });
   }
 }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,7 +4,3 @@ en:
       site_settings:
         categories:
           deprecation_collector: "Deprecation Collector"
-  js:
-    deprecation_collector:
-      critical_deprecations: "<b>[Admin Notice]</b> One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes (<a target='_blank' href='https://meta.discourse.org/t/287211'>more info</a>)."
-      theme_source: "Identified theme: <a target='_blank' href='%{path}'>'%{name}'</a>."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,11 +1,3 @@
 deprecation_collector:
   deprecation_collector_enabled:
     default: false
-  deprecation_collector_warn_critical_deprecations:
-    default: false
-    hidden: true
-    client: true
-  deprecation_collector_critical_deprecations_message:
-    default: ""
-    hidden: true
-    client: true

--- a/spec/system/deprecation_collector_spec.rb
+++ b/spec/system/deprecation_collector_spec.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
 describe "Deprecation collector", type: :system do
-  before { SiteSetting.deprecation_collector_enabled = true }
-
-  let(:test_deprecation_id) { DeprecationCollector::List.first }
-  let(:logged_deprecations) { [] }
-  let!(:stub) do
-    DeprecationCollector
-      .stubs(:add_to_counter)
-      .with do |value|
-        logged_deprecations << value
-        true
-      end
-  end
-
   it "successfully reports deprecations to the server" do
+    SiteSetting.deprecation_collector_enabled = true
+
     visit("/latest")
     expect(find("#main-outlet-wrapper")).to be_visible
+
+    logged_deprecations = []
+
+    test_deprecation_id = DeprecationCollector::List.first
+
+    stub =
+      DeprecationCollector
+        .stubs(:add_to_counter)
+        .with do |value|
+          logged_deprecations << value
+          true
+        end
 
     # Trigger some fake deprecations
     page.execute_script <<~JS
@@ -31,26 +32,5 @@ describe "Deprecation collector", type: :system do
     try_until_success do
       expect(logged_deprecations).to include(test_deprecation_id, "_other_discourse")
     end
-  end
-
-  it "warns admins about deprecations when enabled" do
-    sign_in Fabricate(:admin)
-
-    SiteSetting.deprecation_collector_warn_critical_deprecations = true
-    SiteSetting.deprecation_collector_critical_deprecations_message =
-      "Discourse core changes will be applied to your site on Jan 15."
-
-    visit("/latest")
-
-    page.execute_script <<~JS
-      const deprecated = require("discourse-common/lib/deprecated").default;
-      deprecated("Fake deprecation message", { id: #{test_deprecation_id.to_json} })
-    JS
-
-    message = find("#global-notice-critical-deprecation")
-    expect(message).to have_text(
-      "One of your themes or plugins needs updating for compatibility with upcoming Discourse core changes",
-    )
-    expect(message).to have_text(SiteSetting.deprecation_collector_critical_deprecations_message)
   end
 end


### PR DESCRIPTION
Moved into core via https://github.com/discourse/discourse/commit/07caa5bc03eca4146b8441f3a78fa4826981d313

This reverts commit 49e1f6a6bbcee06ae230ff6b3f32cc6be9d49b4a.