### PR TITLE
DEV: add bootbox to deprecations list for data collection

### DIFF
--- a/lib/deprecation_collector/list.rb
+++ b/lib/deprecation_collector/list.rb
@@ -90,5 +90,6 @@ module DeprecationCollector
         discourse.global.user
         discourse.global.site
         discourse.global.site-settings
+        discourse.bootbox
       ]
 end


### PR DESCRIPTION
This helps collect data for instances of bootbox being used in prod, which is in the process of deprecation.