### PR TITLE
DEV: add deprecation id from DeprecatedOutletArgument

### DIFF
--- a/lib/deprecation_collector/list.rb
+++ b/lib/deprecation_collector/list.rb
@@ -7,7 +7,8 @@ module DeprecationCollector
 
   deprecations = YAML.load_file(DEPRECATION_IDS_FILE)
   List =
-    (deprecations["ember_deprecation_ids"] || []).concat(
-      deprecations["discourse_deprecation_ids"] || [],
-    )
+    (deprecations["ember_deprecation_ids"] || [])
+      .concat(deprecations["discourse_deprecation_ids"] || [])
+      .concat(%w[discourse.plugin-connector.deprecated-arg.header-contents.topic])
+      .uniq
 end


### PR DESCRIPTION
We recently added a way to mark plugin outlet arguments as deprecated (https://github.com/discourse/discourse/pull/27885) and the current automated way of capturing deprecation IDs does not yet include these. 

Adding the IDs manually for now directly into DeprecationCollector::List (and we can continue to use that array literal for adding other IDs that aren't properly captured by the script) - https://github.com/search?q=org%3Adiscourse+deprecatedOutletArgument&type=code is a simple way to search for these deprecated plugin outlet args. 