### PR TITLE
DEV: add npmrc file to deprecation-finder to ensure consistent pnpm lockfile settings

### DIFF
--- a/deprecation-finder/.npmrc
+++ b/deprecation-finder/.npmrc
@@ -1,0 +1,2 @@
+engine-strict = true
+auto-install-peers = false


### PR DESCRIPTION
This file needs to be explicitly added to ensure autoInstallPeers is set to `false` in the pnpm lockfile. Not having this file caused this run failure: https://github.com/discourse/discourse-deprecation-collector/actions/runs/14024405701.

Tested to work with: https://github.com/discourse/discourse-deprecation-collector/actions/runs/14026652275